### PR TITLE
Sync version in libyui-qt-pkg-doc.spec

### DIFF
--- a/package/libyui-qt-pkg-doc.spec
+++ b/package/libyui-qt-pkg-doc.spec
@@ -20,7 +20,7 @@
 %define so_version 7
 
 Name:           %{parent}-doc
-Version:        2.45.4
+Version:        2.45.5
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 


### PR DESCRIPTION
Now I wonder if the SR will be rejected for not including a changelog entry in `libyui-qt-pkg-doc.changes` (which looks almost empty right now, anyways).

Let's try.