### PR TITLE
Replace qt5_use_modules with target_link_libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_PATH ${QT_INCLUDES} ${CMAKE_INCLUDE_PATH})
 
 PROCESS_SOURCES()
-qt5_use_modules( ${TARGETLIB} Core Gui Widgets Svg X11Extras )
+target_link_libraries(
+  ${TARGETLIB} Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Svg Qt5::X11Extras
+  )
 
 SUBDIRS(icons)


### PR DESCRIPTION
qt5_use_modules has been deprecated in Qt 5.11. This PR should fix
[bsc#1091286](https://bugzilla.suse.com/show_bug.cgi?id=1091286).