### PR TITLE
Bump the .so version to 10 (bsc#1132247)

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,11 +1,11 @@
 SET( VERSION_MAJOR "2" )
-SET( VERSION_MINOR "45" )
-SET( VERSION_PATCH "27" )
+SET( VERSION_MINOR "46" )
+SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
 
 ##### This is need for the libyui core, ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
-SET( SONAME_MAJOR "5" )
+SET( SONAME_MAJOR "0" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-qt-pkg-doc.spec
+++ b/package/libyui-qt-pkg-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui-qt-pkg
-%define so_version 9
+%define so_version 10
 
 Name:           %{parent}-doc
-Version:        2.45.27
+Version:        2.46.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui-qt-pkg.changes
+++ b/package/libyui-qt-pkg.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 11 14:16:07 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Bump the .so version to 10 to be compatible with the other
+  libyui packages (bsc#1132247)
+- 2.46.0
+
+-------------------------------------------------------------------
 Tue Mar 12 15:49:33 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Revert to previous initial status column width (bsc#1127708)

--- a/package/libyui-qt-pkg.spec
+++ b/package/libyui-qt-pkg.spec
@@ -17,11 +17,11 @@
 
 
 Name:           libyui-qt-pkg
-Version:        2.45.27
+Version:        2.46.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 9
+%define so_version 10
 %define bin_name %{name}%{so_version}
 
 %if 0%{?suse_version} > 1325


### PR DESCRIPTION
- similar to https://github.com/libyui/libyui-ncurses-pkg/pull/28
- Travis fails as it depends on the new libyui base, it builds fine in https://build.opensuse.org/project/monitor/home:lslezak:libyui-rest-api
- to be compatible with the other libyui packages
- 2.46.0
- related to https://bugzilla.suse.com/show_bug.cgi?id=1132247 and https://trello.com/c/dtXPHr8H