### PR TITLE
Use new libyui SO version 12

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,9 +1,9 @@
 SET( VERSION_MAJOR "2" )
 SET( VERSION_MINOR "48" )
-SET( VERSION_PATCH "1" )
+SET( VERSION_PATCH "2" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
 
-##### This is need for the libyui core, ONLY.
+##### This is need for the libyui core ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
 SET( SONAME_MAJOR "0" )
 SET( SONAME_MINOR "0" )

--- a/package/libyui-qt-pkg-doc.spec
+++ b/package/libyui-qt-pkg-doc.spec
@@ -17,9 +17,9 @@
 
 
 %define parent libyui-qt-pkg
-%define so_version 11
+%define so_version 12
 Name:           %{parent}-doc
-Version:        2.48.1
+Version:        2.48.2
 Release:        0
 Summary:        Libyui-qt-pkg documentation
 License:        LGPL-2.1-only OR LGPL-3.0-only

--- a/package/libyui-qt-pkg.changes
+++ b/package/libyui-qt-pkg.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  4 12:36:18 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Use new parent lib SO version libyui.so.12 (bsc#1172513)
+- 2.48.2
+
+-------------------------------------------------------------------
 Wed May 20 11:04:22 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fixed compatibility with older (pre-5.15) Qt versions (bsc#1165118)

--- a/package/libyui-qt-pkg.spec
+++ b/package/libyui-qt-pkg.spec
@@ -16,12 +16,12 @@
 #
 
 
-%define so_version 11
+%define so_version 12
 %define bin_name %{name}%{so_version}
 %define libyui_qt_devel_version libyui-qt-devel >= 2.50.1
 %define libzypp_devel_version libzypp-devel >= 17.21.0
 Name:           libyui-qt-pkg
-Version:        2.48.1
+Version:        2.48.2
 Release:        0
 Summary:        Libyui - Qt Package Selector
 License:        LGPL-2.1-only OR LGPL-3.0-only


### PR DESCRIPTION
This is related to https://github.com/libyui/libyui/pull/165 :

The latest libyui needed to bump the SO version to 12 to maintain binary compatibility. The dependent packages like this need to adapt to that new version.
